### PR TITLE
Fix crash after attempting load decompressed zip

### DIFF
--- a/Assets/Scripts/VoskSpeechToText.cs
+++ b/Assets/Scripts/VoskSpeechToText.cs
@@ -225,6 +225,8 @@ public class VoskSpeechToText : MonoBehaviour
 		{
 			yield return null;
 		}
+		//Override path given in ZipFileOnExtractProgress to prevent crash
+		_decompressedModelPath = Path.Combine(Application.persistentDataPath, Path.GetFileNameWithoutExtension(ModelPath));
 
 		//Update status text
 		OnStatusUpdated?.Invoke("Decompressing complete!");


### PR DESCRIPTION
on line 245:			_decompressedModelPath = e.ExtractLocation;  will set the _decompressedModelPath to the persistentDataPath + "files" which is incorrect. This workaround ensures that the editor and player don't crash when trying to read the newly decompressed files.

This fixes this issue: https://github.com/alphacep/vosk-unity-asr/issues/1